### PR TITLE
fix: Update version label from 2.8.x to 2.9.x

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "2.8.x(Latest)",
+    "message": "2.9.x(Latest)",
     "description": "The label for version current"
   },
   "sidebar.mainSidebar.category.框架设计": {


### PR DESCRIPTION
This pull request updates the documentation version label to reflect the latest release.

- Documentation version label in `i18n/en/docusaurus-plugin-content-docs/current.json` updated from "2.8.x(Latest)" to "2.9.x(Latest)" to indicate the new current version.