### PR TITLE
Fix parameter priority order in request input documentation

### DIFF
--- a/docs/docs/WEB服务开发/请求输入/请求输入.md
+++ b/docs/docs/WEB服务开发/请求输入/请求输入.md
@@ -81,7 +81,7 @@ func main() {
 我们考虑一种场景，当不同的提交方式中存在同名的参数名称会怎么样？在 `GoFrame` 框架下，我们根据不同的获取方法，将会按照不同的优先级进行获取，优先级高的方式提交的参数将会优先覆盖其他方式的同名参数。优先级规则如下：
 
 1. `Get` 及 `GetRequset` 方法： `Router < Query < Body < Form < Custom`，也就是说自定义参数的优先级最高，其次是 `Form` 表单参数，再次是 `Body` 提交参数，以此类推。例如， `Query` 和 `Form` 中都提交了同样名称的参数 `id`，参数值分别为 `1` 和 `2`，那么 `Get("id")`/ `GetForm("id")` 将会返回 `2`，而 `GetQuery("id")` 将会返回 `1`。
-2. `GetQuery` 方法： `Query > Body`，也就是说 `query string` 的参数将会覆盖 `Body` 中提交的同名参数。例如， `Query` 和 `Body` 中都提交了同样名称的参数 `id`，参数值分别为 `1` 和 `2`，那么 `Get("id")` 将会返回 `2`，而 `GetQuery("id")` 将会返回 `1`。
+2. `GetQuery` 方法： `Query < Body`，也就是说 `query string` 的参数将会覆盖 `Body` 中提交的同名参数。例如， `Query` 和 `Body` 中都提交了同样名称的参数 `id`，参数值分别为 `1` 和 `2`，那么 `Get("id")` 将会返回 `2`，而 `GetQuery("id")` 将会返回 `1`。
 3. `GetForm` 方法：由于该类型的方法仅用于获取 `Form` 表单参数，因此没什么优先级的差别。
 
 使用示例：


### PR DESCRIPTION
Correct the priority order of parameters in the GoFrame framework documentation.