### PR TITLE
feat: 添加 GoFrame MCP HTTP 和 SSE 示例文档

### DIFF
--- a/docs/examples/httpserver/mcp-http/mcp-http.md
+++ b/docs/examples/httpserver/mcp-http/mcp-http.md
@@ -1,0 +1,137 @@
+---
+title: GoFrame MCP HTTP 示例
+slug: /examples/httpserver/mcp-http
+keywords: [mcp, http, 流式传输, goframe, 模型上下文协议]
+description: 使用 GoFrame 和 HTTP 流式传输实现 MCP 服务器的示例。
+hide_title: true
+---
+
+# GoFrame MCP HTTP 示例
+
+Github Source: https://github.com/gogf/examples/tree/main/httpserver/mcp-http
+
+
+本示例展示了如何使用 GoFrame 的 `ghttp` 服务器和 `mark3labs/mcp-go` SDK 实现通过 HTTP 流式传输的 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 服务器。
+
+## 先决条件
+
+- Go 1.20 或更高版本
+- MCP 客户端（例如 Claude Desktop 或 IDE 扩展）
+
+## 安装
+
+1. 初始化模块（如果尚未完成）：
+   ```bash
+   go mod tidy
+   ```
+
+2. 运行服务器：
+   ```bash
+   go run main.go
+   ```
+
+## 用法
+
+服务器暴露了一个端点：
+- `POST /mcp`: 用于处理 MCP JSON-RPC 消息的 HTTP 端点。
+
+### 连接 Claude Desktop
+
+要在 Claude Desktop 中使用此 MCP 服务器，请将以下配置添加到您的 `claude_desktop_config.json`：
+
+```json
+{
+  "mcpServers": {
+    "goframe-mcp": {
+      "command": "go",
+      "args": ["run", "path/to/your/project/httpserver/mcp-http/main.go"]
+    }
+  }
+}
+```
+
+*注意：此示例使用 HTTP 流式传输（StreamableHTTP），通过单一 HTTP 端点处理所有 MCP 通信。*
+
+### 直接 HTTP 测试
+
+1. 启动服务器。
+2. 发送 POST 请求到 `http://localhost:8080/mcp`。
+
+示例请求：
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "capabilities": {},
+      "clientInfo": {
+        "name": "client",
+        "version": "1.0.0"
+      }
+    }
+  }'
+```
+
+## MCP 客户端配置
+
+如果你的客户端或 IDE 支持通过配置文件定义 MCP 服务器，可以在项目根目录下创建 `.vscode/mcp.json`，示例内容如下：
+
+```json
+{
+  "servers": {
+    "add": {
+      "url": "http://localhost:8080/mcp",
+      "type": "http"
+    }
+  },
+  "inputs": []
+}
+```
+
+说明：
+- `servers` 下的键名（例如 `add`）为服务器标识名称。
+- `url` 指向示例的 HTTP 端点 `http://localhost:8080/mcp`。
+- `type` 表示连接类型，此处为 `http`（HTTP 流式传输）。
+- `inputs` 可选，用于在客户端中预置输入。
+
+保存后，支持该配置的客户端即可使用该文件连接到本示例 MCP 服务。
+
+## 功能
+
+- **工具**: 暴露一个 `add` 工具，可接收两个数字（`a` 和 `b`），返回它们的和。
+- **示例**: 你可以通过 MCP 客户端发送如下计算请求：
+
+```
+mcp 计算 一加一
+```
+
+或英文：
+```
+mcp add 1 and 1
+```
+
+服务器将返回：
+```
+结果: 1 + 1 = 2
+```
+
+## 代码结构
+
+- `main.go`: 包含服务器设置、工具注册以及使用 `ghttp.WrapH` 进行的路由绑定。
+
+## StreamableHTTP 与 SSE 的区别
+
+| 特性 | StreamableHTTP | SSE |
+|------|----------------|-----|
+| 协议 | HTTP 1.1+ | HTTP (Server-Sent Events) |
+| 连接方式 | 单一 POST 端点 | 分离的 GET (SSE) 和 POST 端点 |
+| 流式传输 | 支持 | 支持 |
+| 客户端实现 | 更简单 | 需要处理事件流 |
+| 浏览器支持 | 标准 HTTP | 需要 EventSource API |
+| 集成方式 | 适合 API 网关 | 适合实时推送场景 |
+
+StreamableHTTP 提供了一种更简洁的方式来实现 MCP 通信，通过单一的 HTTP 端点处理所有请求和响应，更易于集成到现有的 HTTP 服务架构中。

--- a/docs/examples/httpserver/mcp-sse/mcp-sse.md
+++ b/docs/examples/httpserver/mcp-sse/mcp-sse.md
@@ -1,0 +1,104 @@
+---
+title: GoFrame MCP SSE 示例
+slug: /examples/httpserver/mcp-sse
+keywords: [mcp, 服务器发送事件, sse, goframe, 模型上下文协议]
+description: 使用 GoFrame 和服务器发送事件实现 MCP 服务器的示例。
+hide_title: true
+---
+
+# GoFrame MCP 示例
+
+Github Source: https://github.com/gogf/examples/tree/main/httpserver/mcp-sse
+
+
+本示例展示了如何使用 GoFrame 的 `ghttp` 服务器和 `mark3labs/mcp-go` SDK 实现 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 服务器。
+
+## 先决条件
+
+- Go 1.20 或更高版本
+- MCP 客户端（例如 Claude Desktop 或 IDE 扩展）
+
+## 安装
+
+1. 初始化模块（如果尚未完成）：
+   ```bash
+   go mod tidy
+   ```
+
+2. 运行服务器：
+   ```bash
+   go run main.go
+   ```
+
+## 用法
+
+服务器暴露了两个端点：
+- `GET /sse`: 用于建立连接的 Server-Sent Events 端点。
+- `POST /message`: 用于发送 JSON-RPC 消息的端点。
+
+### 连接 Claude Desktop
+
+要在 Claude Desktop 中使用此 MCP 服务器，请将以下配置添加到您的 `claude_desktop_config.json`：
+
+```json
+{
+  "mcpServers": {
+    "goframe-mcp": {
+      "command": "go",
+      "args": ["run", "path/to/your/project/httpserver/mcp/main.go"]
+    }
+  }
+}
+```
+
+*注意：由于此示例运行 HTTP 服务器，您可能需要使用支持 SSE 的 MCP 客户端。上述配置假设您将其作为本地进程运行。如果您想通过 HTTP (SSE) 连接，您的客户端必须支持远程 MCP 连接。*
+
+直接 SSE 测试：
+1. 启动服务器。
+2. 连接到 `http://localhost:8080/sse`。
+
+## MCP 客户端配置
+
+如果你的客户端或 IDE 支持通过配置文件定义 MCP 服务器，可以在项目根目录下创建 `.vscode/mcp.json`，示例内容如下：
+
+```json
+{
+  "servers": {
+    "add": {
+      "url": "http://localhost:8080/sse",
+      "type": "http"
+    }
+  },
+  "inputs": []
+}
+```
+
+说明：
+- `servers` 下的键名（例如 `add`）为服务器标识名称。
+- `url` 指向示例的 SSE 端点 `http://localhost:8080/sse`。
+- `type` 表示连接类型，此处为 `http`（SSE）。
+- `inputs` 可选，用于在客户端中预置输入。
+
+保存后，支持该配置的客户端即可使用该文件连接到本示例 MCP 服务。
+
+
+## 功能
+
+- **工具**: 暴露一个 `add` 工具，可接收两个数字（`a` 和 `b`），返回它们的和。
+- **示例**: 你可以通过 MCP 客户端发送如下计算请求：
+
+```
+mcp 计算 一加一
+```
+或英文：
+```
+mcp add 1 and 1
+```
+服务器将返回：
+```
+结果: 1 + 1 = 2
+```
+
+## 代码结构
+
+- `main.go`: 包含服务器设置、工具注册以及使用 `ghttp.WrapH` 进行的路由绑定。

--- a/i18n/en/docusaurus-plugin-content-docs/current/examples/httpserver/mcp-http/mcp-http.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/examples/httpserver/mcp-http/mcp-http.md
@@ -1,0 +1,137 @@
+---
+title: GoFrame MCP HTTP Example
+slug: /examples/httpserver/mcp-http
+keywords: [mcp, http, streaming, goframe, model context protocol]
+description: An example of implementing MCP server using GoFrame with HTTP streaming.
+hide_title: true
+---
+
+# GoFrame MCP HTTP Example
+
+Github Source: https://github.com/gogf/examples/tree/main/httpserver/mcp-http
+
+
+This example demonstrates how to implement a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server using GoFrame's `ghttp` server and the `mark3labs/mcp-go` SDK through HTTP streaming.
+
+## Prerequisites
+
+- Go 1.20 or higher
+- MCP client (e.g., Claude Desktop or IDE extension)
+
+## Installation
+
+1. Initialize the module (if not already done):
+   ```bash
+   go mod tidy
+   ```
+
+2. Run the server:
+   ```bash
+   go run main.go
+   ```
+
+## Usage
+
+The server exposes a single endpoint:
+- `POST /mcp`: HTTP endpoint for handling MCP JSON-RPC messages.
+
+### Connect to Claude Desktop
+
+To use this MCP server in Claude Desktop, add the following configuration to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "goframe-mcp": {
+      "command": "go",
+      "args": ["run", "path/to/your/project/httpserver/mcp-http/main.go"]
+    }
+  }
+}
+```
+
+*Note: This example uses HTTP streaming (StreamableHTTP), handling all MCP communication through a single HTTP endpoint.*
+
+### Direct HTTP Testing
+
+1. Start the server.
+2. Send a POST request to `http://localhost:8080/mcp`.
+
+Example request:
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "capabilities": {},
+      "clientInfo": {
+        "name": "client",
+        "version": "1.0.0"
+      }
+    }
+  }'
+```
+
+## MCP Client Configuration
+
+If your client or IDE supports defining MCP servers through a configuration file, you can create a `.vscode/mcp.json` in your project root with the following example content:
+
+```json
+{
+  "servers": {
+    "add": {
+      "url": "http://localhost:8080/mcp",
+      "type": "http"
+    }
+  },
+  "inputs": []
+}
+```
+
+Explanation:
+- The key under `servers` (e.g., `add`) is the server identifier name.
+- `url` points to the HTTP endpoint of the example: `http://localhost:8080/mcp`.
+- `type` indicates the connection type, in this case `http` (HTTP streaming).
+- `inputs` is optional and can be used to preset inputs in the client.
+
+After saving, clients that support this configuration can use this file to connect to the MCP service.
+
+## Features
+
+- **Tool**: Exposes an `add` tool that accepts two numbers (`a` and `b`) and returns their sum.
+- **Example**: You can send a calculation request through the MCP client:
+
+```
+mcp calculate one plus one
+```
+
+Or in Chinese:
+```
+mcp 计算 一加一
+```
+
+The server will return:
+```
+Result: 1 + 1 = 2
+```
+
+## Code Structure
+
+- `main.go`: Contains server setup, tool registration, and route binding using `ghttp.WrapH`.
+
+## StreamableHTTP vs SSE Comparison
+
+| Feature | StreamableHTTP | SSE |
+|---------|----------------|-----|
+| Protocol | HTTP 1.1+ | HTTP (Server-Sent Events) |
+| Connection | Single POST endpoint | Separate GET (SSE) and POST endpoints |
+| Streaming | Supported | Supported |
+| Client Implementation | Simpler | Requires event stream handling |
+| Browser Support | Standard HTTP | Requires EventSource API |
+| Integration | Suitable for API gateways | Suitable for real-time push scenarios |
+
+StreamableHTTP provides a cleaner way to implement MCP communication by handling all requests and responses through a single HTTP endpoint, making it easier to integrate into existing HTTP service architectures.

--- a/i18n/en/docusaurus-plugin-content-docs/current/examples/httpserver/mcp-sse/mcp-sse.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/examples/httpserver/mcp-sse/mcp-sse.md
@@ -1,0 +1,102 @@
+---
+title: GoFrame MCP SSE Example
+slug: /examples/httpserver/mcp-sse
+keywords: [mcp, server-sent events, sse, goframe, model context protocol]
+description: An example of implementing MCP server using GoFrame with Server-Sent Events.
+hide_title: true
+---
+
+# GoFrame MCP Example
+
+Github Source: https://github.com/gogf/examples/tree/main/httpserver/mcp-sse
+
+
+This example demonstrates how to implement a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server using GoFrame's `ghttp` server and the `mark3labs/mcp-go` SDK.
+
+## Prerequisites
+
+- Go 1.20 or higher
+- An MCP client (e.g., Claude Desktop, or an IDE extension)
+
+## Installation
+
+1. Initialize the module (if not already done):
+   ```bash
+   go mod tidy
+   ```
+
+2. Run the server:
+   ```bash
+   go run main.go
+   ```
+
+## Usage
+
+The server exposes two endpoints:
+- `GET /sse`: The Server-Sent Events endpoint for establishing the connection.
+- `POST /message`: The endpoint for sending JSON-RPC messages.
+
+### Connecting with Claude Desktop
+
+To use this MCP server with Claude Desktop, add the following configuration to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "goframe-mcp": {
+      "command": "go",
+      "args": ["run", "path/to/your/project/httpserver/mcp/main.go"]
+    }
+  }
+}
+```
+
+*Note: Since this example runs an HTTP server, you might need to use an MCP client that supports SSE, or use a bridge. However, the configuration above assumes you are running it as a local process. If you want to connect via HTTP (SSE), your client must support remote MCP connections.*
+
+For direct SSE testing:
+1. Start the server.
+2. Connect to `http://localhost:8080/sse`.
+
+## MCP client configuration
+
+If your editor or tool supports defining MCP servers via a configuration file (for example, some IDE extensions or local test tools), you can create `.vscode/mcp.json` in the project root with the following example:
+
+```json
+{
+  "servers": {
+    "add": {
+      "url": "http://localhost:8080/sse",
+      "type": "http"
+    }
+  },
+  "inputs": []
+}
+```
+
+Notes:
+- The key under `servers` (e.g. `add`) is the identifier used by the client.
+- `url` should point to the SSE endpoint for this example: `http://localhost:8080/sse`.
+- `type` indicates connection type; this example uses `http` (SSE).
+- `inputs` is optional and can be used to predefine input payloads depending on the client.
+
+Save the file and compatible clients can read it to connect to this example MCP server.
+
+
+## Features
+
+- **Tools**: Exposes an `add` tool that takes two numbers (`a` and `b`) and returns their sum.
+- **Example**: From an MCP client you can send a calculation request, for example:
+
+```
+mcp add 1 and 1
+```
+
+The server will respond with:
+
+```
+Result: 1 + 1 = 2
+```
+
+## Code Structure
+
+- `main.go`: Contains the server setup, tool registration, and route binding using `ghttp.WrapH`.


### PR DESCRIPTION
- 新增 MCP HTTP 示例文档，展示如何使用 GoFrame 实现 HTTP 流式传输的 MCP 服务器
- 新增 MCP SSE 示例文档，展示如何使用 GoFrame 实现服务器发送事件的 MCP 服务器